### PR TITLE
refactor: add some previously forgottern rules to eslintrc

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -8,7 +8,7 @@ module.exports = {
     'prettier',
     'plugin:prettier/recommended',
   ],
-  ignorePatterns: ['dist', '.eslintrc.cjs'],
+  ignorePatterns: ['dist', '.eslintrc.cjs', 'vite.config.ts'],
   parser: '@typescript-eslint/parser',
   parserOptions: {
     ecmaVersion: 2020,
@@ -34,6 +34,26 @@ module.exports = {
     ],
     'max-lines-per-function': ['error', 40],
     'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
+    '@typescript-eslint/no-inferrable-types': 'off',
+    '@typescript-eslint/array-type': [
+      'error',
+      {
+        default: 'array',
+      },
+    ],
+    '@typescript-eslint/explicit-member-accessibility': [
+      'error',
+      {
+        accessibility: 'explicit',
+        overrides: {
+          accessors: 'explicit',
+          constructors: 'off',
+          methods: 'explicit',
+          properties: 'explicit',
+          parameterProperties: 'explicit',
+        },
+      },
+    ],
     '@typescript-eslint/explicit-function-return-type': 'error',
     '@typescript-eslint/ban-ts-comment': 'error',
     '@typescript-eslint/no-unnecessary-type-assertion': 'error',


### PR DESCRIPTION
### My PR fulfills these requirements:
- [x] PR title name follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Tests for the changes have been added
- [x] Changes have been tested locally
- [x] New code have been linted
- [x] New code have been formatted with Prettier
- [x] Docs have been added / updated

### I'm submitting
- [ ] feature request
- [ ] bug fix request
- [x] refactoring request
- [ ] documentation update request
- [ ] other

### Description of my changes:
Добавлены слудующие ESLint правила:
- @typescript-eslint/no-inferrable-types
- @typescript-eslint/array-type
- @typescript-eslint/explicit-member-accessibility