### PR TITLE
refactor: remove interfering eslint rules

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -32,7 +32,6 @@ module.exports = {
         arrowParens: 'always',
       },
     ],
-    'max-lines-per-function': ['error', 40],
     'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
     '@typescript-eslint/no-inferrable-types': 'off',
     '@typescript-eslint/array-type': [
@@ -54,7 +53,6 @@ module.exports = {
         },
       },
     ],
-    '@typescript-eslint/explicit-function-return-type': 'error',
     '@typescript-eslint/ban-ts-comment': 'error',
     '@typescript-eslint/no-unnecessary-type-assertion': 'error',
     '@typescript-eslint/no-explicit-any': 'error',


### PR DESCRIPTION
### My PR fulfills these requirements:
- [x] PR title name follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Tests for the changes have been added
- [x] Changes have been tested locally
- [x] New code have been linted
- [x] New code have been formatted with Prettier
- [x] Docs have been added / updated

### I'm submitting
- [ ] feature request
- [ ] bug fix request
- [x] refactoring request
- [ ] documentation update request
- [ ] other

### Description of my changes:
Удалены такие правила ESLint:
- max-lines-per-function
- @typescript-eslint/explicit-function-return-type